### PR TITLE
Fixes abnomal CPU utilization & improves animation, reducing "jiggle"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.vscode

--- a/ScoreboardHandler.py
+++ b/ScoreboardHandler.py
@@ -174,13 +174,10 @@ class ScoreboardHandler (Handler):
             moveY = 0
             if teamID in self.moveMap.keys():
                 oldPos, newPos = self.moveMap[teamID]
+                # old equation, using float (kept line for clarity)
                 # moveY = self.teamHeight * (oldPos - newPos) * (1 - cubic_spline(self.animationTimer.clock / self.animationSpeed))
                 n = self.teamHeight * (oldPos - newPos)
-                moveY = n - int(n * cubic_spline(self.animationTimer.clock / self.animationSpeed))
-
-                # without spline:
-                # n = self.teamHeight * (oldPos - newPos)
-                # moveY = n - (n * self.animationTimer.clock) // self.animationSpeed
+                moveY = n - cubic_spline_int(n, self.animationTimer.clock, self.animationSpeed)
             if self.lockTo == teamID:
                 # keep locked team at screen center
                 self.pendingScroll = baseY + moveY - 408 + self.teamHeight // 2

--- a/ScoreboardHandler.py
+++ b/ScoreboardHandler.py
@@ -176,15 +176,11 @@ class ScoreboardHandler (Handler):
                 oldPos, newPos = self.moveMap[teamID]
                 # moveY = self.teamHeight * (oldPos - newPos) * (1 - cubic_spline(self.animationTimer.clock / self.animationSpeed))
                 n = self.teamHeight * (oldPos - newPos)
-                moveY = n - n * cubic_spline(self.animationTimer.clock / self.animationSpeed)
-
+                moveY = n - int(n * cubic_spline(self.animationTimer.clock / self.animationSpeed))
 
                 # without spline:
                 # n = self.teamHeight * (oldPos - newPos)
                 # moveY = n - (n * self.animationTimer.clock) // self.animationSpeed
-
-
-                # moveY = int(0.5 + moveY)
             if self.lockTo == teamID:
                 # keep locked team at screen center
                 self.pendingScroll = baseY + moveY - 408 + self.teamHeight // 2

--- a/ScoreboardHandler.py
+++ b/ScoreboardHandler.py
@@ -174,8 +174,17 @@ class ScoreboardHandler (Handler):
             moveY = 0
             if teamID in self.moveMap.keys():
                 oldPos, newPos = self.moveMap[teamID]
-                moveY = self.teamHeight * (oldPos - newPos) * (1 - cubic_spline(self.animationTimer.clock / self.animationSpeed))
-                moveY = int(0.5 + moveY)
+                # moveY = self.teamHeight * (oldPos - newPos) * (1 - cubic_spline(self.animationTimer.clock / self.animationSpeed))
+                n = self.teamHeight * (oldPos - newPos)
+                moveY = n - n * cubic_spline(self.animationTimer.clock / self.animationSpeed)
+
+
+                # without spline:
+                # n = self.teamHeight * (oldPos - newPos)
+                # moveY = n - (n * self.animationTimer.clock) // self.animationSpeed
+
+
+                # moveY = int(0.5 + moveY)
             if self.lockTo == teamID:
                 # keep locked team at screen center
                 self.pendingScroll = baseY + moveY - 408 + self.teamHeight // 2

--- a/ScoreboardHandler.py
+++ b/ScoreboardHandler.py
@@ -93,10 +93,21 @@ class ScoreboardHandler (Handler):
         if self.ffMode:
             self.ffTimer.tick(self.delta())
             self.ffTimer.clock = min(self.ffTimer.clock, self.ffLength)
-            u = self.ffTimer.clock / self.ffLength
-            Handler.contest.revealUntil = int(0.0 + \
-              (1 - u) * Handler.contest.freezeTime + \
-                   u  * Handler.contest.contestTime)
+
+            c = self.ffTimer.clock
+            l = self.ffLength
+            t = Handler.contest.contestTime
+            f = Handler.contest.freezeTime
+
+            # original equations
+            # u = c / l
+            # d = ((1 - u) * f + u * t)
+
+            # factored equation
+            d = f + (c*(t-f)) // l
+
+            Handler.contest.revealUntil = d
+
             self.attractSpeed = 300
         else:
             self.attractSpeed = 1000

--- a/ScoreboardHandler.py
+++ b/ScoreboardHandler.py
@@ -178,7 +178,7 @@ class ScoreboardHandler (Handler):
                 moveY = int(0.5 + moveY)
             if self.lockTo == teamID:
                 # keep locked team at screen center
-                self.pendingScroll = baseY + moveY - 408 + self.teamHeight / 2
+                self.pendingScroll = baseY + moveY - 408 + self.teamHeight // 2
 
             # only draw stuff that will appear on-screen
             if -self.teamHeight + 40 < baseY < 768:

--- a/ScoreboardHandler.py
+++ b/ScoreboardHandler.py
@@ -101,7 +101,7 @@ class ScoreboardHandler (Handler):
         else:
             self.attractSpeed = 1000
 
-        curScroll = (abs(self.pendingScroll) + 4) / 5
+        curScroll = (abs(self.pendingScroll) + 4) // 5
         if self.pendingScroll < 0:
             curScroll *= -1
         self.offsetY += curScroll
@@ -125,7 +125,7 @@ class ScoreboardHandler (Handler):
             if self.lockTo:
                 self.offsetY += self.teamHeight * 12
                 self.attractTimer.clock = \
-                        (self.offsetY * self.attractSpeed) / self.teamHeight
+                        (self.offsetY * self.attractSpeed) // self.teamHeight
             self.lockTo = None
             for run in Handler.contest.newRunList[-1]:
                 if run.answer == 'Y':
@@ -133,11 +133,11 @@ class ScoreboardHandler (Handler):
 
         if not self.lockTo:
             self.pendingScroll = 0
-            self.offsetY = (self.teamHeight * self.attractTimer.clock) / self.attractSpeed
+            self.offsetY = (self.teamHeight * self.attractTimer.clock) // self.attractSpeed
             self.offsetY -= self.teamHeight * 12
             if self.offsetY < 0:
                 self.offsetY = 0
-            if self.offsetY > self.maxOffsetY + self.teamHeight / 2:
+            if self.offsetY > self.maxOffsetY + self.teamHeight // 2:
                 self.attractTimer.reset()
                 if self.ffMode:
                     if self.ffTimer.clock >= self.ffLength:

--- a/ScoreboardHandler.py
+++ b/ScoreboardHandler.py
@@ -13,8 +13,6 @@ class ScoreboardHandler (Handler):
     def __init__(self):
         Handler.__init__(self)
 
-        self.clock = pygame.time.Clock()
-
         self.teamHeight = 60
         self.maxOffsetY = len(Handler.contest.teamMap.items()) * self.teamHeight
 
@@ -191,7 +189,6 @@ class ScoreboardHandler (Handler):
 
         self.draw_header()
 
-        self.clock.tick(15)
         pygame.display.flip()
 
         return self

--- a/ScoreboardHandler.py
+++ b/ScoreboardHandler.py
@@ -13,6 +13,8 @@ class ScoreboardHandler (Handler):
     def __init__(self):
         Handler.__init__(self)
 
+        self.clock = pygame.time.Clock()
+
         self.teamHeight = 60
         self.maxOffsetY = len(Handler.contest.teamMap.items()) * self.teamHeight
 
@@ -189,6 +191,7 @@ class ScoreboardHandler (Handler):
 
         self.draw_header()
 
+        self.clock.tick(15)
         pygame.display.flip()
 
         return self

--- a/main.py
+++ b/main.py
@@ -22,6 +22,9 @@ def main():
         ' if --select_teams is used.', default=[])
     parser.add_argument('-s', '--select_teams', nargs='+', metavar='PREFIX',
         help='Select only the teams whose team id starts with PREFIX.', default=[])
+
+    parser.add_argument('-f', '--frame_rate', type=int, default=30,
+        help='Maximum framerate for the animator. Defaults to 30 fps.')
     args = parser.parse_args()
 
     if len(args.select_teams) > 0 and len(args.remove_teams) > 0:
@@ -43,10 +46,13 @@ def main():
         print(u'Check the typed URL: %s' % (args.webcast_dir))
         exit(1)
 
+    clock = pygame.time.Clock()
+    frame_rate = args.frame_rate
     while 1:
         for event in pygame.event.get():
             handler.on_event(event)
         handler = handler.tick()
+        clock.tick(frame_rate)
 
 if __name__ == '__main__':
     main()

--- a/util.py
+++ b/util.py
@@ -13,6 +13,8 @@ def init_pygame(window_mode):
     global gScreen
 
     pygame.init()
+    pygame.mixer.quit()
+
     if window_mode:
         gScreen = pygame.display.set_mode((1024, 768), pygame.RESIZABLE)
     else:

--- a/util.py
+++ b/util.py
@@ -125,6 +125,27 @@ def image(filename):
     _gImageCache[filename] = image
     return image
 
+def cubic_spline_int(f, num, den):
+
+    if 4 * num < den:
+        return 0
+    if 4 * num > 3 * den:
+        return 1
+
+    num2 = 2 * (num*4 - den)
+    den2 = 4 * den
+
+    # u = num2/den2
+    num3 = 3 * pow(num2, 2) * pow(den2, 3) - 2 * pow(num2, 3) * pow(den2, 2)
+    den3 = pow(den2, 2) * pow(den2, 3) 
+
+    # r = 3 * u**2 - 2 * u**3
+    r = num3 / den3
+    
+    # multiplying external factor
+    r = (f * num3) // den3    
+    return r
+
 def cubic_spline(u):
     if u < 0.25:
         return 0.0

--- a/util.py
+++ b/util.py
@@ -126,16 +126,13 @@ def image(filename):
     return image
 
 def cubic_spline(u):
-    if u < 0.0:
-        u = 0.0
-    if u > 1.0:
-        u = 1.0
     if u < 0.25:
         return 0.0
     if u > 0.75:
         return 1.0
     u = 2.0 * (u - 0.25)
-    return 3 * u**2 - 2 * u**3
+    r = 3 * u**2 - 2 * u**3
+    return max(0.0, min(1.0, r))
 
 def lockFiles():
     while os.path.exists('.lock'):


### PR DESCRIPTION
This pull request does 2 things:

First, it reduces CPU usage:
- Disables (buggy pygame) sound mixer.
- Adds command line option -f to configure fps limit. The fps limit uses pygame internal clock. Recommended framerate is a divisor of the screen framerate (usually 30 is a good choice, which is set as default).

Example:
```python main.py -w -f 24 sample/```

Second, it fixes the jiggle during score updates, by removing floating point numbers. 
Now the scoreboard is smooth even in lower frameratest, such as 15fps.